### PR TITLE
fix: change stylers from GoogleMapThemeFeature to Map<String, dynamic> from Map<String, String>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+2.1.2:
+* Fix: make the mapstyling Map<String, dynamic> instead of Map<String, String> to support other values than strings that are not automatically converted anymore by google maps on web.
+
 2.1.1:
 * Fix: add back deprecated 'fromBytes' method to support autoscaling of images again. In the future this should be done with the bytes method for BitmapDescriptor.
 

--- a/lib/src/google_map_theme.dart
+++ b/lib/src/google_map_theme.dart
@@ -36,7 +36,7 @@ class GoogleMapThemeFeature {
   });
   final String? featureType;
   final String? elementType;
-  final List<Map<String, String>> stylers;
+  final List<Map<String, dynamic>> stylers;
 
   Map toJson() {
     return {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_google_track_and_trace
 description: An Iconica Flutter plugin for Track & Trace Package
-version: 2.1.1
+version: 2.1.2
 repository: https://github.com/Iconica-Development/flutter_google_track_and_trace
 
 publish_to: https://forgejo.internal.iconica.nl/api/packages/internal/pub


### PR DESCRIPTION
For Styling the map on web Google doesn't allow strings for things like saturation